### PR TITLE
Fix pr description chrome extension

### DIFF
--- a/main.js
+++ b/main.js
@@ -34,7 +34,7 @@
     if (!squashContainer) {
       return;
     }
-    var squashButton = squashContainer.querySelector('button[type="submit"]');
+    var squashButton = squashContainer.querySelector('button[data-details-container=".js-merge-pr"]');
   
     if (squashButton.getAttribute('squashmerge')) {
       return;


### PR DESCRIPTION
Recently GitHub has updated their HTML for the GitHub Squash and Merge button, and was causing this error:
Uncaught TypeError: Cannot read property 'getAttribute' of null
    at scanForSquashAndMergeButtons (main.js:39)
    at poll (main.js:61)

The reason being is that the button was no longer with a type=submit and therefore was a null. It then failed when we tried to getAttribute of this null variable.

I updated the query selector to find the button correctly with the new introduced updates.